### PR TITLE
wayne: Set stock fingerprint overlay for PIHooks

### DIFF
--- a/overlay-miku/frameworks/base/core/res/res/values/config.xml
+++ b/overlay-miku/frameworks/base/core/res/res/values/config.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Build fingerprint from stock ROM -->
+    <string name="config_stockFingerprint" translatable="false">xiaomi/wayne/wayne:8.1.0/OPM1.171019.011/V9.5.11.0.ODCCNFA:user/release-keys</string>
+</resources>


### PR DESCRIPTION
* We're using PIHooks to pass SafetyNet, need to set an overlay here for it.
* Ref: https://github.com/Miku-UI/platform_frameworks_base/commit/1022ea095e8c09e54a230cc1ce06db70cc814a8b