### PR TITLE
[IMPORTANT] Stop using hard-coded fingerprint.

### DIFF
--- a/miku_wayne.mk
+++ b/miku_wayne.mk
@@ -28,5 +28,3 @@ PRODUCT_MANUFACTURER := Xiaomi
 PRODUCT_CHARACTERISTICS := nosdcard
 
 PRODUCT_GMS_CLIENTID_BASE := android-xiaomi
-
-BUILD_FINGERPRINT := xiaomi/wayne/wayne:9/PKQ1.180904.001/V12.0.2.0.PDCCNXM:user/release-keys


### PR DESCRIPTION
It causes bootloop after QPR2 merged, check commit for more informations.